### PR TITLE
Refresh NeuralGCM API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,10 +9,7 @@
 The user-facing API for NeuralGCM models centers around `PressureLevelModel`:
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel
+.. autoclass:: PressureLevelModel
 ```
 
 ### Constructor
@@ -20,10 +17,7 @@ The user-facing API for NeuralGCM models centers around `PressureLevelModel`:
 Use this class method to create a new model:
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel.from_checkpoint
+.. automethod:: PressureLevelModel.from_checkpoint
 ```
 
 ### Properties
@@ -32,14 +26,11 @@ These properties describe the coordinate system and variables for which a model
 is defined:
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel.timestep
-    PressureLevelModel.data_coords
-    PressureLevelModel.model_coords
-    PressureLevelModel.input_variables
-    PressureLevelModel.forcing_variables
+.. autoproperty:: PressureLevelModel.timestep
+.. autoproperty:: PressureLevelModel.data_coords
+.. autoproperty:: PressureLevelModel.model_coords
+.. autoproperty:: PressureLevelModel.input_variables
+.. autoproperty:: PressureLevelModel.forcing_variables
 ```
 
 ### Learned methods
@@ -51,13 +42,10 @@ variables defined on model coordinates (i.e., sigma levels) and back.
 `advance` and `unroll` allow for stepping forward in time.
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel.encode
-    PressureLevelModel.decode
-    PressureLevelModel.advance
-    PressureLevelModel.unroll
+.. automethod:: PressureLevelModel.encode
+.. automethod:: PressureLevelModel.decode
+.. automethod:: PressureLevelModel.advance
+.. automethod:: PressureLevelModel.unroll
 ```
 
 ### Unit conversion
@@ -67,13 +55,10 @@ The internal state of NeuralGCM models uses non-dimensional units and
 for converting arrays back and forth, including inside JAX code:
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel.to_nondim_units
-    PressureLevelModel.from_nondim_units
-    PressureLevelModel.datetime64_to_sim_time
-    PressureLevelModel.sim_time_to_datetime64
+.. automethod:: PressureLevelModel.to_nondim_units
+.. automethod:: PressureLevelModel.from_nondim_units
+.. automethod:: PressureLevelModel.datetime64_to_sim_time
+.. automethod:: PressureLevelModel.sim_time_to_datetime64
 ```
 
 ### Xarray conversion
@@ -83,13 +68,10 @@ with JAX. Use these methods to convert between `xarray.Dataset` objects and
 inputs/outputs from learned methods:
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    PressureLevelModel.inputs_from_xarray
-    PressureLevelModel.forcings_from_xarray
-    PressureLevelModel.data_from_xarray
-    PressureLevelModel.data_to_xarray
+.. automethod:: PressureLevelModel.inputs_from_xarray
+.. automethod:: PressureLevelModel.forcings_from_xarray
+.. automethod:: PressureLevelModel.data_from_xarray
+.. automethod:: PressureLevelModel.data_to_xarray
 ```
 
 ## Demo dataset & models
@@ -102,9 +84,6 @@ For non-testing purposes, see the model checkpoints from the paper in the
 {doc}`./inference_demo`.
 
 ```{eval-rst}
-.. autosummary::
-    :toctree: _autosummary
-
-    demo.load_data
-    demo.load_checkpoint_tl63_stochastic
+.. autofunction:: neuralgcm.demo.load_data
+.. autofunction:: neuralgcm.demo.load_checkpoint_tl63_stochastic
 ```

--- a/neuralgcm/api.py
+++ b/neuralgcm/api.py
@@ -35,17 +35,16 @@ import pandas as pd
 import xarray
 
 
-Params = dict[str, dict[str, jnp.ndarray]]
-
 ArrayLike = float | np.ndarray | jax.Array
+Params = dict[str, dict[str, ArrayLike]]
 TimedeltaLike = str | np.timedelta64 | pd.Timestamp | datetime.timedelta
 Numeric = float | np.ndarray | jax.Array | xarray.DataArray
 
 # TODO(shoyer): make these types more precise
 Inputs = dict[str, ArrayLike]
 Forcings = dict[str, ArrayLike]
-Outputs = dict[str, ArrayLike]
-BatchedOutputs = dict[str, ArrayLike]
+Outputs = dict[str, jax.Array]
+BatchedOutputs = dict[str, jax.Array]
 State = Any
 
 


### PR DESCRIPTION
The API docs now appears inline on a single page, which should be a little easier to read particularly because many methods only have a single line docstring.

I have also added source code link to GitHub.