### PR TITLE
Fix inclusion of package resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["neuralgcm"]
-
 [tool.setuptools.package-data]
 "neuralgcm.data" = ["*"]
 


### PR DESCRIPTION
Explicitly setting `packages = ["neuralgcm"]` seems to disable discover of package data, so the helpers from `neuralgcm.demo` are currently broken!

We needed this previously because we had the `notebooks/` subdirectory, which setuptools complained about potentially ambiguously looking like a subpackage.

Ideally I think we should probably switch to a "src-layout" which would make this less ambiguous in general:
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout